### PR TITLE
Add mailbox activity check script

### DIFF
--- a/Readme
+++ b/Readme
@@ -3,4 +3,5 @@ These are some useful scripts for automating sysadmin work
 Script details:
 Exchange Online_Power
   - Script for connecting to Exchange Online
- 
+Search_Mailboxes_Last30Days
+  - Lists Exchange mailboxes used in the last 30 days using MFA

--- a/Search_Mailboxes_Last30Days.ps1
+++ b/Search_Mailboxes_Last30Days.ps1
@@ -1,0 +1,28 @@
+# Connect to Exchange Online using MFA
+# Requires Exchange Online Management module
+Param(
+    [string]$UserPrincipalName
+)
+
+if (-not $UserPrincipalName) {
+    Write-Host "Enter the user principal name for the account used to connect." -ForegroundColor Yellow
+    $UserPrincipalName = Read-Host "User Principal Name"
+}
+
+# Establish the connection with MFA prompt
+Connect-ExchangeOnline -UserPrincipalName $UserPrincipalName
+
+# Determine cutoff date
+$cutoff = (Get-Date).AddDays(-30)
+
+# Retrieve mailbox statistics and filter by last logon time
+$mailboxes = Get-Mailbox -RecipientTypeDetails UserMailbox -ResultSize Unlimited |
+    Get-MailboxStatistics |
+    Where-Object { $_.LastLogonTime -ge $cutoff }
+
+$mailboxes | Select-Object @{N='EmailAddress';E={$_.PrimarySmtpAddress}},
+                         @{N='LastLogonTime';E={$_.LastLogonTime}} |
+    Sort-Object LastLogonTime -Descending |
+    Format-Table -AutoSize
+
+Disconnect-ExchangeOnline -Confirm:$false


### PR DESCRIPTION
## Summary
- add script to list Exchange Online mailboxes used in the last 30 days
- document the new script in the Readme

## Testing
- `pwsh -NoProfile -Command "Get-ChildItem | Out-Host"` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848dfa86b9c8333a22277e2a222bb7c