### PR TITLE
Add detection for users with multiple mailboxes

### DIFF
--- a/Readme
+++ b/Readme
@@ -3,4 +3,6 @@ These are some useful scripts for automating sysadmin work
 Script details:
 Exchange Online_Power
   - Script for connecting to Exchange Online
- 
+Search_Mailboxes_Last30Days
+  - Lists Exchange mailboxes used in the last 30 days using MFA
+  - Flags users with multiple mailboxes without displaying errors

--- a/Search_Mailboxes_Last30Days.ps1
+++ b/Search_Mailboxes_Last30Days.ps1
@@ -1,0 +1,56 @@
+# Connect to Exchange Online using MFA
+# Requires Exchange Online Management module
+Param(
+    [string]$UserPrincipalName
+)
+
+if (-not $UserPrincipalName) {
+    Write-Host "Enter the user principal name for the account used to connect." -ForegroundColor Yellow
+    $UserPrincipalName = Read-Host "User Principal Name"
+}
+
+# Establish the connection with MFA prompt
+Connect-ExchangeOnline -UserPrincipalName $UserPrincipalName
+
+# Determine cutoff date
+$cutoff = (Get-Date).AddDays(-30)
+
+# Retrieve mailboxes and handle cases where users have multiple mailboxes
+$mailboxes = Get-Mailbox -RecipientTypeDetails UserMailbox -ResultSize Unlimited
+
+# Track how many mailboxes each user has to flag duplicates
+$mailboxCounts = @{}
+foreach ($mb in $mailboxes) {
+    if ($mailboxCounts.ContainsKey($mb.UserPrincipalName)) {
+        $mailboxCounts[$mb.UserPrincipalName]++
+    } else {
+        $mailboxCounts[$mb.UserPrincipalName] = 1
+    }
+}
+
+$results = foreach ($mb in $mailboxes) {
+    $note = $null
+
+    # Attempt to retrieve statistics using user principal name; if multiple
+    # mailboxes exist this will throw an error which we catch silently
+    try {
+        $stats = Get-MailboxStatistics -Identity $mb.UserPrincipalName -ErrorAction Stop
+    } catch {
+        $stats = Get-MailboxStatistics -Identity $mb.Identity -ErrorAction SilentlyContinue
+        $note = 'Multiple mailboxes detected'
+    }
+
+    if ($stats -and $stats.LastLogonTime -ge $cutoff) {
+        [pscustomobject]@{
+            EmailAddress  = $mb.PrimarySmtpAddress
+            LastLogonTime = $stats.LastLogonTime
+            Notes         = if ($mailboxCounts[$mb.UserPrincipalName] -gt 1) { 'Multiple mailboxes detected' } else { $note }
+        }
+    }
+}
+
+$results |
+    Sort-Object LastLogonTime -Descending |
+    Format-Table -AutoSize
+
+Disconnect-ExchangeOnline -Confirm:$false


### PR DESCRIPTION
## Summary
- refine Search_Mailboxes_Last30Days.ps1 to handle users that have more than one mailbox
- update documentation about new behaviour

## Testing
- `pwsh -NoProfile -Command "Get-ChildItem | Out-Host"` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848dfa86b9c8333a22277e2a222bb7c